### PR TITLE
Locked astroid to more than or equal to 2.4 but less than 2.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ matrix:
     dist: bionic
 
 before_install:
-  - "pip install pylint==2.5.3 mypy==0.782"
+  - "pip install pylint==2.5.3 mypy==0.782 'astroid>=2.4.0,<2.5'"
 
 install:
   - "pip install ."


### PR DESCRIPTION
Locked the version of astroid to 2.4.2 to reduce issues when linting